### PR TITLE
Use React typings for RoundedButton component

### DIFF
--- a/src/components/RoundedButton.tsx
+++ b/src/components/RoundedButton.tsx
@@ -1,31 +1,27 @@
-import * as React from "react";
+import React, { FunctionComponent } from "react";
 import { ColorProperty } from "csstype";
 
 export interface RoundedButtonProps {
   color: ColorProperty;
-  style?: React.CSSProperties;
   onClick: () => void;
-  children: React.ReactNode;
 }
 
-export function RoundedButton(props: RoundedButtonProps) {
-  return (
-    <button
-      style={{
-        backgroundColor: props.color,
-        border: "none",
-        color: "white",
-        padding: 20,
-        textAlign: "center",
-        textDecoration: "none",
-        display: "inline-block",
-        fontSize: "16px",
-        margin: "4px 2px",
-        borderRadius: 5
-      }}
-      onClick={() => props.onClick()}
-    >
-      {props.children}
-    </button>
-  );
-}
+export const RoundedButton: FunctionComponent<RoundedButtonProps> = props => (
+  <button
+    style={{
+      backgroundColor: props.color,
+      border: "none",
+      color: "white",
+      padding: 20,
+      textAlign: "center",
+      textDecoration: "none",
+      display: "inline-block",
+      fontSize: "16px",
+      margin: "4px 2px",
+      borderRadius: 5
+    }}
+    onClick={() => props.onClick()}
+  >
+    {props.children}
+  </button>
+);


### PR DESCRIPTION
This PR improves the React typings for the RoundedButton component by using the React `FunctionComponent` interface.